### PR TITLE
Require fix

### DIFF
--- a/src/__testfixtures__/replace-require.input.js
+++ b/src/__testfixtures__/replace-require.input.js
@@ -22,6 +22,9 @@ import omit from 'object.omit';
 import omit from 'object.omit/extra';
 const otherOmit = require('object.omit');
 const otherOmit = require('object.omit/extra');
+const otherOmit = require('dont-touch-object.omit');
+
+const dontTouch = 'object.omit';
 
 const props = omit(
   {

--- a/src/__testfixtures__/replace-require.input.js
+++ b/src/__testfixtures__/replace-require.input.js
@@ -19,14 +19,20 @@
 // THE SOFTWARE.
 
 import omit from 'object.omit';
-import omit from 'object.omit/extra';
 const otherOmit = require('object.omit');
+
+import omit from 'object.omit/extra';
 const otherOmit = require('object.omit/extra');
 
 import dontTouch from 'object.omit-dont-touch';
 const dontTouch = require('object.omit-dont-touch');
+
+import dontTouch from './object.omit';
 const dontTouch = require('./object.omit');
+
+import dontTouch from 'dont-touch-object.omit';
 const dontTouch = require('dont-touch-object.omit');
+
 const dontTouch = 'object.omit';
 const dontTouch = '';
 

--- a/src/__testfixtures__/replace-require.input.js
+++ b/src/__testfixtures__/replace-require.input.js
@@ -23,6 +23,8 @@ import omit from 'object.omit/extra';
 const otherOmit = require('object.omit');
 const otherOmit = require('object.omit/extra');
 
+import dontTouch from 'object.omit-dont-touch';
+const dontTouch = require('object.omit-dont-touch');
 const dontTouch = require('./object.omit');
 const dontTouch = require('dont-touch-object.omit');
 const dontTouch = 'object.omit';

--- a/src/__testfixtures__/replace-require.input.js
+++ b/src/__testfixtures__/replace-require.input.js
@@ -22,9 +22,11 @@ import omit from 'object.omit';
 import omit from 'object.omit/extra';
 const otherOmit = require('object.omit');
 const otherOmit = require('object.omit/extra');
-const otherOmit = require('dont-touch-object.omit');
 
+const dontTouch = require('./object.omit');
+const dontTouch = require('dont-touch-object.omit');
 const dontTouch = 'object.omit';
+const dontTouch = '';
 
 const props = omit(
   {

--- a/src/__testfixtures__/replace-require.output.js
+++ b/src/__testfixtures__/replace-require.output.js
@@ -23,6 +23,8 @@ import omit from 'just-omit/extra';
 const otherOmit = require('just-omit');
 const otherOmit = require('just-omit/extra');
 
+import dontTouch from 'object.omit-dont-touch';
+const dontTouch = require('object.omit-dont-touch');
 const dontTouch = require('./object.omit');
 const dontTouch = require('dont-touch-object.omit');
 const dontTouch = 'object.omit';

--- a/src/__testfixtures__/replace-require.output.js
+++ b/src/__testfixtures__/replace-require.output.js
@@ -19,14 +19,20 @@
 // THE SOFTWARE.
 
 import omit from 'just-omit';
-import omit from 'just-omit/extra';
 const otherOmit = require('just-omit');
+
+import omit from 'just-omit/extra';
 const otherOmit = require('just-omit/extra');
 
 import dontTouch from 'object.omit-dont-touch';
 const dontTouch = require('object.omit-dont-touch');
+
+import dontTouch from './object.omit';
 const dontTouch = require('./object.omit');
+
+import dontTouch from 'dont-touch-object.omit';
 const dontTouch = require('dont-touch-object.omit');
+
 const dontTouch = 'object.omit';
 const dontTouch = '';
 

--- a/src/__testfixtures__/replace-require.output.js
+++ b/src/__testfixtures__/replace-require.output.js
@@ -22,9 +22,11 @@ import omit from 'just-omit';
 import omit from 'just-omit/extra';
 const otherOmit = require('just-omit');
 const otherOmit = require('just-omit/extra');
-const otherOmit = require('dont-touch-object.omit');
 
+const dontTouch = require('./object.omit');
+const dontTouch = require('dont-touch-object.omit');
 const dontTouch = 'object.omit';
+const dontTouch = '';
 
 const props = omit(
   {

--- a/src/__testfixtures__/replace-require.output.js
+++ b/src/__testfixtures__/replace-require.output.js
@@ -22,6 +22,9 @@ import omit from 'just-omit';
 import omit from 'just-omit/extra';
 const otherOmit = require('just-omit');
 const otherOmit = require('just-omit/extra');
+const otherOmit = require('dont-touch-object.omit');
+
+const dontTouch = 'object.omit';
 
 const props = omit(
   {

--- a/src/replace-require.js
+++ b/src/replace-require.js
@@ -20,27 +20,49 @@
 
 const escapeStringRegexp = require('escape-string-regexp');
 
-function codemodReplacement(declarationType, source, j, opts) {
-  const toReplaceRegex = new RegExp(escapeStringRegexp(opts.toReplace));
+function replaceImport(source, j, opts) {
   return j(source)
-    .find(j[declarationType])
+    .find(j.ImportDeclaration)
     .find(j.Literal)
     .filter(function filterValidRequires(literal) {
       const rawValue = literal.value.rawValue;
-      return typeof rawValue === 'string' && toReplaceRegex.test(rawValue);
+      return typeof rawValue === 'string' && opts.toReplace.test(rawValue);
     })
     .replaceWith(function replaceValidRequires(literal) {
       const rawValue = literal.value.rawValue;
-      const toRet = (rawValue).replace(toReplaceRegex, opts.replaceWith);
+      const toRet = (rawValue).replace(opts.toReplace, opts.replaceWith);
       return j.literal(toRet);
     })
     .toSource({quote: 'single'});
 }
 
-module.exports = function replaceRequire(file, api, opts) {
+function replaceRequire(source, j, opts) {
+  return j(source)
+    .find(j.VariableDeclaration)
+    .find(j.CallExpression)
+    .filter(function filterNonRequires(callExpression) {
+      return callExpression.value.callee.name === 'require';
+    })
+    .replaceWith(literal => {
+      const rawValue = literal.value.arguments[0].rawValue;
+      if (typeof rawValue === 'string') {
+        const newRawValue = (rawValue).replace(opts.toReplace, opts.replaceWith);
+        return j.callExpression(
+          j.identifier('require'),
+          [j.literal(newRawValue)]
+        );
+      }
+      // fall-through if rawValue is not a string
+      return literal;
+    })
+    .toSource({quote: 'single'});
+}
+
+module.exports = function replace(file, api, opts) {
   const j = api.jscodeshift;
   const source = file.source;
 
-  const newSource = codemodReplacement('VariableDeclaration', source, j, opts);
-  return codemodReplacement('ImportDeclaration', newSource, j, opts);
+  opts.toReplace = new RegExp(`^${escapeStringRegexp(opts.toReplace)}`);
+  const newSource = replaceImport(source, j, opts);
+  return replaceRequire(newSource, j, opts);
 };

--- a/src/replace-require.js
+++ b/src/replace-require.js
@@ -30,7 +30,10 @@ function replaceImport(source, j, opts) {
     })
     .replaceWith(function replaceValidRequires(literal) {
       const rawValue = literal.value.rawValue;
-      const toRet = (rawValue).replace(opts.toReplace, opts.replaceWith);
+      const newRawValue = (rawValue).replace(opts.toReplace, (a, trailingCharacters) => {
+        return `${opts.replaceWith}${trailingCharacters}`;
+      });
+      const toRet = (newRawValue).replace(opts.toReplace, opts.replaceWith);
       return j.literal(toRet);
     })
     .toSource({quote: 'single'});
@@ -46,7 +49,9 @@ function replaceRequire(source, j, opts) {
     .replaceWith(literal => {
       const rawValue = literal.value.arguments[0].rawValue;
       if (typeof rawValue === 'string') {
-        const newRawValue = (rawValue).replace(opts.toReplace, opts.replaceWith);
+        const newRawValue = (rawValue).replace(opts.toReplace, (a, trailingCharacters) => {
+          return `${opts.replaceWith}${trailingCharacters}`;
+        });
         return j.callExpression(
           j.identifier('require'),
           [j.literal(newRawValue)]
@@ -62,7 +67,7 @@ module.exports = function replace(file, api, opts) {
   const j = api.jscodeshift;
   const source = file.source;
 
-  opts.toReplace = new RegExp(`^${escapeStringRegexp(opts.toReplace)}`);
+  opts.toReplace = new RegExp(`^${escapeStringRegexp(opts.toReplace)}(\/.*|$)`);
   const newSource = replaceImport(source, j, opts);
   return replaceRequire(newSource, j, opts);
 };


### PR DESCRIPTION
Cases fixed in this diff:

```js
// previously ALL these would have been touched
import dontTouch from './object.omit';
const dontTouch = require('./object.omit');

import dontTouch from 'dont-touch-object.omit';
const dontTouch = require('dont-touch-object.omit');

const dontTouch = 'object.omit';
const dontTouch = '';
```